### PR TITLE
Fix compilation on kernels >= 6.11 and <= 6.1

### DIFF
--- a/fl2000_connector.c
+++ b/fl2000_connector.c
@@ -27,12 +27,12 @@ static int fl2000_read_edid(void *data, u8 *buf, unsigned int block, size_t len)
 }
 static int fl2000_get_modes(struct drm_connector *connector)
 {
-	struct edid *edid;
+	const struct drm_edid *edid;
 	int ret;
 
-	edid = drm_do_get_edid(connector, fl2000_read_edid, connector->ddc);
-	drm_connector_update_edid_property(connector, edid);
-	ret = drm_add_edid_modes(connector, edid);
+	edid = drm_edid_read_custom(connector, fl2000_read_edid, connector->ddc);
+	drm_edid_connector_update(connector, edid);
+	ret = drm_edid_connector_add_modes(connector);
 	kfree(edid);
 
 	//ret = drm_add_modes_noedid(connector, 1920, 1200);

--- a/fl2000_drm.c
+++ b/fl2000_drm.c
@@ -4,6 +4,7 @@
  * (C) Copyright 2018-2020, Artem Mygaiev
  */
 
+#include <linux/version.h>
 #include <linux/dma-buf.h>
 #include <linux/printk.h>
 #include <linux/usb.h>
@@ -12,7 +13,11 @@
 #include <drm/drm_damage_helper.h>
 #include <drm/drm_drv.h>
 #include <drm/drm_fb_helper.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0)
+#include <drm/drm_fbdev_ttm.h>
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
 #include <drm/drm_fbdev_generic.h>
+#endif
 #include <drm/drm_fourcc.h>
 #include <drm/drm_framebuffer.h>
 #include <drm/drm_gem_atomic_helper.h>
@@ -566,7 +571,11 @@ int fl2000_drm_init(struct fl2000 *fl2000_dev)
 	fl2000_reset(usb_dev);
 	fl2000_usb_magic(usb_dev);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0)
+	drm_fbdev_ttm_setup(drm, FL2000_FB_BPP);
+#else
 	drm_fbdev_generic_setup(drm, FL2000_FB_BPP);
+#endif
 
 	return 0;
 

--- a/fl2000_streaming.c
+++ b/fl2000_streaming.c
@@ -12,6 +12,7 @@
  */
 
 #include <linux/scatterlist.h>
+#include <linux/vmalloc.h>
 
 #include <drm/drm_managed.h>
 #include <drm/drm_vblank.h>


### PR DESCRIPTION
Fixes #3
May also improve #2 by dropping the use of deprecated edid functions